### PR TITLE
Support legacy runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 1.1.1
+
+- Support older runtimes by using only Array.from when available and falling back to Array.prototype.slice
+
 #### 1.1.0
 
 - Use commonjs exports intead of ES exports

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -28,4 +28,34 @@ describe('Promisify', function() {
       })
     })
   })
+  it('works when Array.from is available', function() {
+    const _ = Array.from
+    Array.from = function(array) {
+      return Array.prototype.slice.call(array)
+    }
+    const callback = function(arg1, arg2) {
+      expect(arg1).toBe('something')
+      arg2(null, 'wow')
+    }
+    waitsForPromise(function() {
+      return promisify(callback)('something').then(function(retVal) {
+        expect(retVal).toBe(retVal)
+        Array.from = _
+      })
+    })
+  })
+  it('works when Array.from is not available', function() {
+    const _ = Array.from
+    Array.from = null
+    const callback = function(arg1, arg2) {
+      expect(arg1).toBe('something')
+      arg2(null, 'wow')
+    }
+    waitsForPromise(function() {
+      return promisify(callback)('something').then(function(retVal) {
+        expect(retVal).toBe(retVal)
+        Array.from = _
+      })
+    })
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 module.exports = function promisify(callback: Function): Function {
   return function promisified(){
-    const parameters = Array.from(arguments)
+    const parameters = Array.prototype.slice(arguments)
     const parametersLength = parameters.length + 1
     return new Promise((resolve, reject) => {
       parameters.push(function(error, data) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 module.exports = function promisify(callback: Function): Function {
   return function promisified(){
-    const parameters = Array.prototype.slice(arguments)
+    const parameters = Array.from ? Array.from(arguments) : Array.prototype.slice.call(arguments)
     const parametersLength = parameters.length + 1
     return new Promise((resolve, reject) => {
       parameters.push(function(error, data) {


### PR DESCRIPTION
By falling back to other methods when Array.from is not available
